### PR TITLE
add an option to export an email as todo

### DIFF
--- a/__tests__/test_background.ts
+++ b/__tests__/test_background.ts
@@ -130,6 +130,7 @@ beforeEach(() => {
 
     joplinNoteParentFolder: "arbitrary folder",
     joplinNoteFormat: "text/html",
+    joplinExportAsTodo: false,
     // Try to keep the tests minimal.
     joplinNoteTags: "",
     joplinNoteTagsFromEmail: false,
@@ -295,6 +296,7 @@ describe("process mail", () => {
         [expectedKey]: body,
         parent_id: browser.storage.local.data.joplinNoteParentFolder,
         title: `${subject} from ${author}`,
+        is_todo: 0,
       });
 
       // Finally check the console output.
@@ -309,6 +311,22 @@ describe("process mail", () => {
       });
     }
   );
+
+  test("export as todo", async () => {
+    await browser.storage.local.set({ joplinExportAsTodo: true });
+
+    const result = await processMail({ id: 0 });
+
+    expect(result).toBe(null);
+    expect(requests.length).toBe(1);
+    expect(requests[0].body).toEqual(expect.objectContaining({ is_todo: 1 }));
+
+    expectConsole({
+      log: 1,
+      warn: 0,
+      error: 0,
+    });
+  });
 });
 
 describe("process tag", () => {

--- a/__tests__/test_options.ts
+++ b/__tests__/test_options.ts
@@ -16,6 +16,7 @@ const setting_ids = [
   "joplinPort",
   "joplinToken",
   "joplinNoteFormat",
+  "joplinExportAsTodo",
   "joplinAttachments",
   "joplinNoteTags",
   "joplinNoteTagsFromEmail",

--- a/src/background.ts
+++ b/src/background.ts
@@ -68,11 +68,13 @@ async function processMail(mailHeader: any) {
   let data: {
     title: string;
     parent_id: string;
+    is_todo: number;
     body?: string;
     body_html?: string;
   } = {
     title: mailHeader.subject + " from " + mailHeader.author,
     parent_id: (await getSetting("joplinNoteParentFolder")) || "",
+    is_todo: Number(await getSetting("joplinExportAsTodo")),
   };
 
   // If the preferred content type doesn't contain data, fall back to the other content type.

--- a/src/options.html
+++ b/src/options.html
@@ -144,6 +144,14 @@
         <option value="text/html">HTML</option>
         <option value="text/plain">Plaintext</option>
       </select>
+      <span class="hovertext" data-hover="Preferred format. If not available, fall back to the other format.">
+        <small>&#9432;</small>
+      </span>
+    </p>
+    <p>
+      <label></label>
+      <input id="joplinExportAsTodo" type="checkbox" />
+      Export as TODO
     </p>
     <p>
       <label for="joplinNoteTags">Tags:</label>

--- a/src/options.ts
+++ b/src/options.ts
@@ -10,6 +10,7 @@ const default_map: { [key: string]: string | number | boolean } = {
   joplinPort: 41184,
   joplinToken: "",
   joplinNoteFormat: "text/html",
+  joplinExportAsTodo: false,
   joplinAttachments: "attach",
   joplinNoteTags: "email",
   joplinNoteTagsFromEmail: true,


### PR DESCRIPTION
Related: https://discourse.joplinapp.org/t/joplin-export-export-emails-from-thunderbird-to-joplin/24792/11