### PR TITLE
Improve parent folder setting

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -93,6 +93,13 @@ async function processMail(mailHeader: any) {
       ? mailHeader.subject
       : mailHeader.subject.replace(new RegExp(regexString), "");
 
+  // Technically it's possible to export a note without specifying a parent notebook.
+  // However, it's rather annoying for the user.
+  const parentId = await getSetting("joplinNoteParentFolder");
+  if (!parentId) {
+    return `Invalid destination notebook: ${parentId}.`;
+  }
+
   let data: {
     title: string;
     parent_id: string;
@@ -101,7 +108,7 @@ async function processMail(mailHeader: any) {
     body_html?: string;
   } = {
     title: finalSubject + " from " + mailHeader.author,
-    parent_id: (await getSetting("joplinNoteParentFolder")) || "",
+    parent_id: parentId,
     is_todo: Number(await getSetting("joplinExportAsTodo")),
   };
 

--- a/src/options.html
+++ b/src/options.html
@@ -142,7 +142,7 @@
   <fieldset>
     <legend>Note</legend>
     <p>
-      <label for="joplinSubjectTrimRegex">Trim subject:</label>
+      <label for="joplinSubjectTrimRegex">Trim Subject:</label>
       <input id="joplinSubjectTrimRegex" />
       <span class="hovertext"
         data-hover="Regex for trimming the subject. Useful for removing Re/Fwd at the start of the subject.">
@@ -159,7 +159,7 @@
       </span>
     </p>
     <p>
-      <label for="joplinNoteParentFolder">Parent folder:</label>
+      <label for="joplinNoteParentFolder">Destination Notebook:</label>
       <select name="joplinNoteParentFolder" id="joplinNoteParentFolder">
         <!-- 
         Will be filled by "options.js":
@@ -167,7 +167,7 @@
          -->
       </select>
       <span><button type="button" id="btnRefreshNotebooks">&#8634;</button></span>
-      <span class="hovertext" data-hover="The exported notes will be stored in this folder.">
+      <span class="hovertext" data-hover="The exported notes will be stored in this notebook.">
         <small>&#9432;</small>
       </span>
     </p>

--- a/src/options.ts
+++ b/src/options.ts
@@ -142,6 +142,10 @@ async function refreshNotebooks() {
   while (notebookSelect.firstChild) {
     notebookSelect.firstChild.remove();
   }
+  let opt = document.createElement("option");
+  opt.value = "";
+  opt.text = "< Select Notebook >";
+  notebookSelect.appendChild(opt);
   fillNotebookSelect(notebookTree, notebookSelect);
 
   // Set notebook if possible


### PR DESCRIPTION
Reference: https://discourse.joplinapp.org/t/joplin-export-export-emails-from-thunderbird-to-joplin/24792/35
- Rename the setting "Parent folder" to "Destination Notebook" and adapt the help text. This is better understandable for users. Folder is only the internal name of notebook.
- Throw an error if the destination notebook isn't specified. Technically it's possible to create a note without destination notebook, but it's impractical if the user doesn't know where exactly the exported note is.