### PR TITLE
Use Services global variable

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -1,5 +1,3 @@
-const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
-
 // Use "var" on purpose. See:
 // https://webextension-api.thunderbird.net/en/91/how-to/experiments.html?highlight=services#implementing-functions
 var helper = class extends ExtensionCommon.ExtensionAPI {


### PR DESCRIPTION
Services.jsm is planned to be removed in Firefox 117 cycle in https://bugzilla.mozilla.org/show_bug.cgi?id=1780695 . Services global variable is available in WebExtensions experiments API global from version 88 https://bugzilla.mozilla.org/show_bug.cgi?id=1698158 , and experiments code doesn't have to import Services.jsm if the strict_min_version is 88.